### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,9 @@ on:
       - master
     types: [opened, ready_for_review, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   semgrep:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jsoehner/atomic-transact-react-native/security/code-scanning/1](https://github.com/jsoehner/atomic-transact-react-native/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow, the `contents: read` permission is sufficient, as the workflow only reads repository contents and performs security checks.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to each job individually. In this case, adding it at the root level is more efficient since both jobs (`semgrep` and `vuln-dep-check`) only require `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
