### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,8 @@ jobs:
   tag:
     needs: npm
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/jsoehner/atomic-transact-react-native/security/code-scanning/3](https://github.com/jsoehner/atomic-transact-react-native/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the `tag` job. Based on the actions performed in the `tag` job, it requires `contents: read` to read the `package.json` file and `contents: write` to create a new tag in the repository. These permissions should be explicitly defined to limit the scope of the `GITHUB_TOKEN`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
