### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,8 @@ jobs:
   tag:
     needs: npm
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/jsoehner/atomic-transact-react-native/security/code-scanning/4](https://github.com/jsoehner/atomic-transact-react-native/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the `tag` job in the workflow file. This block should specify the minimal permissions required for the job to function correctly. Since the job interacts with the GitHub API to create a tag, it only needs `contents: read` and `contents: write` permissions. 

The changes will be made to the `.github/workflows/publish.yml` file, specifically within the `tag` job definition. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
